### PR TITLE
Allows conditional partial mapping to object list

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,45 @@ Et voilà, the included magic, and white rabbits have done the rest for you, and
 
 Tadaaaa.
 
+### All spanking new! Mapping different partials conditionally to our items
+
+Suppose we are making a feed and each item needs a different layout? No problem! 
+
+In your `Example_Presenter` create a function called 'map_<name>' with a variable to catch your object.
+
+For example:
+
+    public function map_example($item)
+    {
+    	switch ($item->key)
+    	{
+    		case 'T1':
+    			return 'test_1';
+    			break;
+    		case 'T2':
+    			return 'test_2';
+    			break;
+    		case 'T3':
+    			return 'test_3';
+    			break;
+    		deafult:
+    			return 'test_3';
+    			break;
+       	}
+    }
+
+Now instead of a single partial, create each one you need:
+
+`/application/views/partials/example/test_1.php` 
+`/application/views/partials/example/test_2.php`
+`/application/views/partials/example/test_3.php` 
+
+and just call with:
+
+<?= $presenter->multi_partial('example') ?> 
+
+Beauty, eh? 
+
 Also, don't forget to watch the screencast on how to use the ci-presenter library. [Vimeo](https://vimeo.com/43767192)
 
 


### PR DESCRIPTION
Hey,

I've made two small changes to allow you loop over an object list and conditionally set which partial should output - useful for feeds where the items may have completely different content or layout

1) I moved the "guts" of _generate_output() into a new function called _parse_html()

2) created a new function called multi_partial() that will read a collection of objects, check if a map_ function was created in the Example_presenter class and collect the name of the partial needed fro output

I added on to the README to explain it's use

Hope that works for you - let me know if you'd like anything changed

Jeff
